### PR TITLE
updated timer creation to match the documented and correct way specified in latest rclpy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,25 +58,24 @@ SUBSYSTEM=="input", ATTRS{name}=="*Wireless Controller Touchpad", RUN+="/bin/rm 
 
 ### Docker
 
-The `Dockerfile` contained in the root of this respository has an example ROS2 Foxy container setup you might use. 
+The `Dockerfile` contained in the root of this repository has an example ROS2 Foxy container setup you might use. 
 
 ```
 docker build -t ds4_driver/foxy .
 ```
 
-After building the image you can automatically run the container by firstly adding the following line to your `~/.bashrc`
-file:
+After building the image you can automatically run the container by starting a new terminal from the `ds4_driver` project 
+root and running the `run_bringup.bash` script which takes the path to the local `ds4_driver` project root as an optional
+first argument, like this:
 
 ```
-export DS4_DRIVER_LOCAL_PATH=<the path to your cloned version of ds4_driver>
+bash run_bringup.bash <path_to_local_ds4_driver_project_root>
 ```
 
-and then from a new terminal from the `ds4_driver` project root do:
+After running the above script the console will go into the running container and you can run from there or from a new 
+terminal executed into the container:
 
 ```
-source ~/.bashrc
-bash run_bringup.bash
-
 # Now go into the container (`docker exec -it $CONTAINER_NAME bash`),
 # where $CONTAINER_NAME can be the name of the running container
 source install/setup.bash

--- a/README.md
+++ b/README.md
@@ -62,25 +62,26 @@ The `Dockerfile` contained in the root of this respository has an example ROS2 F
 
 ```
 docker build -t ds4_driver/foxy .
+```
 
-docker run -it  \
-  --device /dev/input \
-  --device /dev/snd \
-  --device /dev/hidraw0 \
-  --device /dev/hidraw1 \
-  --device /dev/hidraw2 \
-  --device /dev/hidraw3 \
-  --device /dev/hidraw4 \
-  --device /dev/hidraw5 \
-  --network=host \
-  ds4_driver/foxy
+After building the image you can automatically run the container by firstly adding the following line to your `~/.bashrc`
+file:
+
+```
+export DS4_DRIVER_LOCAL_PATH=<the path to your cloned version of ds4_driver>
+```
+
+and then from a new terminal from the `ds4_driver` project root do:
+
+```
+source ~/.bashrc
+bash run_bringup.bash
 
 # Now go into the container (`docker exec -it $CONTAINER_NAME bash`),
 # where $CONTAINER_NAME can be the name of the running container
 source install/setup.bash
 
-ros2 run ds4_driver 
-
+ros2 run ds4_driver ds4_driver_node.py
 ```
 
 ## Demonstration

--- a/ds4_driver/controller_ros.py
+++ b/ds4_driver/controller_ros.py
@@ -46,8 +46,7 @@ class ControllerRos(Controller):
 
             if self._autorepeat_rate != 0:
                 period = 1.0 / self._autorepeat_rate
-                # rclpy.Timer(rclpy.Duration.from_sec(period), self.cb_joy_pub_timer)
-                self.node.create_timer(timer_period_sec=period, callback=self.cb_joy_pub_timer)
+                self.node.create_timer(period, self.cb_joy_pub_timer)
         else:
             self.pub_status = self.node.create_publisher(Status, 'status', 1)
             self.sub_feedback = self.node.create_subscription(Feedback,'set_feedback', self.cb_feedback, 0)
@@ -122,12 +121,9 @@ class ControllerRos(Controller):
 
         # Timer to stop rumble
         if msg.set_rumble and msg.rumble_duration != 0:
-            # rclpy.Timer(rclpy.Duration(msg.rumble_duration),
-            #             self.cb_stop_rumble,
-            #             oneshot=True)
-            self.stop_rumble_timer = self.node.create_timer(timer_period_sec=msg.rumble_duration, callback=self.cb_stop_rumble)
+            self.stop_rumble_timer = self.node.create_timer(msg.rumble_duration, self.cb_stop_rumble)
 
-    def cb_stop_rumble(self, event):
+    def cb_stop_rumble(self):
         try:
             self.control(rumble_small=0, rumble_big=0)
 

--- a/ds4_driver/controller_ros.py
+++ b/ds4_driver/controller_ros.py
@@ -1,6 +1,5 @@
 from ds4_driver.controller import Controller
 
-import rclpy
 from sensor_msgs.msg import BatteryState
 from sensor_msgs.msg import Joy
 from sensor_msgs.msg import JoyFeedback

--- a/ds4_driver/controller_ros.py
+++ b/ds4_driver/controller_ros.py
@@ -169,7 +169,7 @@ class ControllerRos(Controller):
 
         self.cb_feedback(feedback)
 
-    def cb_joy_pub_timer(self, _):
+    def cb_joy_pub_timer(self):
         if self._prev_joy is not None:
             self.pub_joy.publish(self._prev_joy)
 

--- a/run_bringup.bash
+++ b/run_bringup.bash
@@ -1,11 +1,19 @@
-docker rm ds4_drv_container
+#!/bin/bash
+DS4_DRIVER_LOCAL_PATH="$1"
 
-# before running this put the export the DS4_DRIVER_LOCAL_PATH variable in your current terminal or
-# place it in ~/.bashrc and source it
-docker run -it \
-  -v "/dev:/dev" \
-  -v "$DS4_DRIVER_LOCAL_PATH:/opt/underlay_ws/src" \
-  --privileged \
-  --name="ds4_drv_container" \
-  --network=host \
-  ds4_driver/foxy bash
+if [ "$DS4_DRIVER_LOCAL_PATH" != "" ]; then
+   docker rm ds4_drv_container
+
+    # before running this put the export the DS4_DRIVER_LOCAL_PATH variable in your current terminal or
+    # place it in ~/.bashrc and source it
+    docker run -it \
+      -v "/dev:/dev" \
+      -v "$DS4_DRIVER_LOCAL_PATH:/opt/underlay_ws/src" \
+      --privileged \
+      --name="ds4_drv_container" \
+      --network=host \
+      ds4_driver/foxy bash
+else
+    echo "Give the ds4_driver local source path as an argument to this script!"
+fi
+

--- a/run_bringup.bash
+++ b/run_bringup.bash
@@ -1,0 +1,11 @@
+docker rm ds4_drv_container
+
+# before running this put the export the DS4_DRIVER_LOCAL_PATH variable in your current terminal or
+# place it in ~/.bashrc and source it
+docker run -it \
+  -v "/dev:/dev" \
+  -v "$DS4_DRIVER_LOCAL_PATH:/opt/underlay_ws/src" \
+  --privileged \
+  --name="ds4_drv_container" \
+  --network=host \
+  ds4_driver/foxy bash


### PR DESCRIPTION
Addresses #17:
* Updated the 2 creation of timers in `controller_ros.py` to match the latest `rclpy` documentation. Now the node doesn't crash anymore with wrong import when setting `use_standard_msgs` to `True` and `autorepeat_rate` to something different than 0.
* Created run_bringup script for more easily launching the provided Docker container. The bringup mounts the whole `/dev` folder into the container as this is a quick fix for the controller not disconnecting properly and keeping the previous `HIDRAW` file locked. This would lead to the creation of a new `HIDRAW` file which cannot be possible set as a `--device` before running the container. the bringup also includes an environment variable for mounting the source of the package inside the container for easier development if needed. This can be removed if deemed unnecessary.
* Updated the `README`

Later edits:
* updated the run_bringup.bash and README.md according to suggestions from @naoki-mizuno 