### PR TITLE
remove buildtool_depend ament_python

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <author>Naoki Mizuno</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_python</buildtool_depend>
   
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>builtin_interfaces</build_depend>


### PR DESCRIPTION
`ament_python` is not a valid `rosdep` key as evidenced by

```
rosdep db | grep ament_python
```

This causes a `rosdep install --from-paths` on this `package.xml` to fail.