### PR TITLE
Fix status messages published too fast

### DIFF
--- a/ds4_driver/config/params.yaml
+++ b/ds4_driver/config/params.yaml
@@ -25,3 +25,6 @@ ds4_driver:
     # Amount by which the joystick has to move before it is considered to be
     # off-center.
     deadzone: 0.1
+
+    # Maximum rate in Hz to publish Status messages.
+    max_status_rate: 100.0

--- a/ds4_driver/nodes/demo.py
+++ b/ds4_driver/nodes/demo.py
@@ -28,10 +28,8 @@ class Handler(object):
         """
         now = self._node.get_clock().now()
 
-        # Commenting out this check for now because to_sec() does not seem to work for rclpy Duration objects
-        # This checks to see if the min interval for a callback has been violated.
-        # if (now - self._last_pub_time).to_sec() < self._min_interval:
-        #     return
+        if (now - self._last_pub_time).nanoseconds / 1e9 < self._min_interval:
+            return
 
         feedback = Feedback()
 


### PR DESCRIPTION
Fixes #34.

There is still some issue regarding the publish rate, which doesn't go up to the value set to `max_status_rate`. For example, when setting it to 100 Hz, I only get ~80 Hz of publish rate.